### PR TITLE
Fix compilation issues, especially with newer compilers

### DIFF
--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -54,9 +54,7 @@ static int enacl_crypto_upgrade(ErlNifEnv* env, void **priv_data,
     return 0;
 }
 
-static int enacl_crypto_unload(ErlNifEnv* env, void **priv_data,
-                                ERL_NIF_TERM load_info) {
-    return 0;
+static void enacl_crypto_unload(ErlNifEnv* env, void *priv_data) {
 }
 
 /* GENERAL ROUTINES

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{plugins, [pc]}.
+{plugins, [{pc, "~> 1.15"}]}.
 
 {project_plugins, [rebar3_hex]}.
 


### PR DESCRIPTION
* Force use of latest pc plugin (by default rebar grabs an old version which crashes).
* Fix bad signature on NIF unload function, which is now a compile error in recent versions of clang. See [this issue](https://github.com/jlouis/enacl/issues/73) in upstream. Unfortunately upstream is abandoned at this point.